### PR TITLE
Docker for development and production

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,9 @@
+FROM node:12-alpine3.9
+LABEL maintainer="Open Government Products"
+WORKDIR /usr/src/app
+RUN apk update && apk add python g++ make tini && rm -rf /var/cache/apk/*
+RUN npm install
+
+ENTRYPOINT ["tini", "--"]
+CMD ["npm", "run", "dev:start"]
+EXPOSE 8080

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 RUN apk update && apk add python g++ make && rm -rf /var/cache/apk/*
 COPY package.json package-lock.json ./
 RUN npm ci
-ADD tsconfig.json src ./
+COPY tsconfig.json src ./
 RUN npm run build
 
 FROM node:12-alpine3.9

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,19 @@
+FROM node:12-alpine3.9 AS node-modules-builder
+LABEL maintainer="Open Government Products"
+WORKDIR /usr/src/app
+RUN apk update && apk add python g++ make && rm -rf /var/cache/apk/*
+COPY package.json package-lock.json ./
+RUN npm ci
+ADD tsconfig.json src ./
+RUN npm run build
+
+FROM node:12-alpine3.9
+WORKDIR /usr/src/app
+RUN apk update && apk add tini && rm -rf /var/cache/apk/*
+COPY --from=node-modules-builder /usr/src/app/package.json /usr/src/app/package-lock.json ./
+COPY --from=node-modules-builder /usr/src/app/node_modules node_modules
+COPY --from=node-modules-builder /usr/src/app/build build
+ENV PORT 8080
+ENTRYPOINT ["tini", "--"]
+CMD ["npm", "run", "start"]
+EXPOSE 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.development
+    command: npm run dev:start
+    ports:
+      - '8080:8080'
+    environment:
+      - NODE_ENV=development
+      - PORT=8080
+    volumes:
+      - ./:/usr/src/app

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "cz": "git-cz",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "dev": "nodemon --exec 'node --inspect -r ts-node/register' src/server/index.ts",
+    "dev": "docker-compose up --build",
+    "dev:start": "nodemon --exec 'node --inspect -r ts-node/register' src/server/index.ts",
     "build": "tsc",
     "start": "node build/server/index.js"
   },

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 
 const app = express()
-const port = 3000
+const port = Number(process.env.PORT)
 
 app.get('/', (req, res) => res.send('Hello World!'))
 


### PR DESCRIPTION
## Problem

We would like to have reproducible builds so that we can (1) avoid the problems that come with developer's coding in their own custom laptop environment, and (2) have a reproducible build in production.

_"But it works on my machine!"_

## Solution

Introduce Dockerfiles for development and production environments.

### Development Dockerfile

The aim here is simplicity - the host machine's files are simply mounted into the docker container via docker-compose before executing an install and starting nodemon.

### Production Dockerfile

This Docker build aims to achieve improved security and size optimisations by

1. Going with a minimal Alpine OS and reduce the final image size/attack surface
2. Using a two-stage build so that installation dependencies are not required in the final image
3. Only copying transpiled files from _build_, instead of source files

Finally, we run the Node process under a lightweight init process _tini_ with PID 1. This will reap [zombie processes](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/) should the application choose to spawn additional processes.

**New environment variables**:

- `PORT` : Application port number

**New dependencies**:

- Docker
- Docker Compose
